### PR TITLE
Clamp main window size to available screen

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1834,12 +1834,28 @@ class MainWindow(QtWidgets.QMainWindow):
         state = self._saved_state or {}
         size = state.get("window_size")
         if isinstance(size, list) and len(size) == 2:
-            self.resize(int(size[0]), int(size[1]))
+            width = int(size[0])
+            height = int(size[1])
         else:
-            self.resize(1400, 900)
+            width = 1400
+            height = 900
+        available = self._available_window_geometry()
+        if available is not None:
+            max_width = max(available.width() - 40, 600)
+            max_height = max(available.height() - 40, 500)
+            width = min(width, max_width)
+            height = min(height, max_height)
+        self.resize(width, height)
         splitter_sizes = state.get("splitter_sizes")
         if isinstance(splitter_sizes, list) and splitter_sizes:
             self.splitter.setSizes([int(value) for value in splitter_sizes])
+
+    @staticmethod
+    def _available_window_geometry() -> Optional[QtCore.QRect]:
+        screen = QtWidgets.QApplication.primaryScreen()
+        if screen is None:
+            return None
+        return screen.availableGeometry()
 
     def _update_filters(self) -> None:
         catalogs = {item.catalog for item in self.items}


### PR DESCRIPTION
### Motivation
- Prevent the main window from restoring or defaulting to a size larger than the user's available screen area so it fits on smaller displays (e.g., 13in Macs) and can be resized.
- Honor a saved `window_size` while ensuring it does not exceed the visible desktop area.
- Provide a single helper to query the primary screen's usable geometry for window sizing decisions.

### Description
- Update `._apply_saved_window_state` to compute `width`/`height` from the saved `window_size` or defaults and then clamp those values to the primary screen `availableGeometry` with a safety margin.
- Enforce maximums using `available.width() - 40` and `available.height() - 40` with sensible minimum fallbacks so the window remains usable on very small screens.
- Replace the immediate `resize(...)` calls with a single `self.resize(width, height)` after clamping, and keep restoring `splitter_sizes` as before.
- Add a static helper `._available_window_geometry()` which returns `QApplication.primaryScreen().availableGeometry()` or `None` when unavailable.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69666f689f84832785683fba3f83cb22)